### PR TITLE
Move toggle coverage op after port map processing

### DIFF
--- a/src/nvc.c
+++ b/src/nvc.c
@@ -886,25 +886,22 @@ static int dump_cmd(int argc, char **argv)
 static int coverage(int argc, char **argv)
 {
    static struct option long_options[] = {
-      { "report",      required_argument,       0, 'r' },
-      { "merge",       required_argument,       0, 'm' },
+      { "report", required_argument, 0, 'r' },
+      { "merge",  required_argument, 0, 'm' },
       { 0, 0, 0, 0 }
    };
 
-   char *out_db LOCAL = NULL;
-   char *rpt_file LOCAL = NULL;
-   char *cmd_file LOCAL = NULL;
-
+   const char *out_db = NULL, *rpt_file = NULL;
    int c, index;
-   const char *spec = "Vmr";
+   const char *spec = "V";
 
    while ((c = getopt_long(argc, argv, spec, long_options, &index)) != -1) {
       switch (c) {
       case 'r':
-         rpt_file = xasprintf("%s", optarg);
+         rpt_file = optarg;
          break;
       case 'm':
-         out_db = xasprintf("%s", optarg);
+         out_db = optarg;
          break;
       case 'V':
          opt_set_int(OPT_VERBOSE, 1);
@@ -936,7 +933,7 @@ static int coverage(int argc, char **argv)
 
       fbuf_close(f, NULL);
    }
-   
+
    if (out_db) {
       progress("Saving merged coverage database to: %s", out_db);
       fbuf_t *f = fbuf_open(out_db, FBUF_OUT, FBUF_CS_NONE);
@@ -950,7 +947,7 @@ static int coverage(int argc, char **argv)
    }
 
    return 0;
-} 
+}
 
 static void set_default_opts(void)
 {

--- a/src/vcode.c
+++ b/src/vcode.c
@@ -2108,20 +2108,20 @@ void vcode_dump_with_mark(int mark_op, vcode_dump_fn_t callback, void *arg)
 
          case VCODE_OP_COVER_STMT:
             {
-               printf("%s %u", vcode_op_string(op->kind), op->tag);
+               printf("%s %u ", vcode_op_string(op->kind), op->tag);
             }
             break;
 
          case VCODE_OP_COVER_BRANCH:
             {
-               printf("%s %u", vcode_op_string(op->kind), op->tag);
+               printf("%s %u ", vcode_op_string(op->kind), op->tag);
                vcode_dump_reg(op->args.items[0]);
             }
             break;
 
          case VCODE_OP_COVER_TOGGLE:
             {
-               printf("%s %u", vcode_op_string(op->kind), op->tag);
+               printf("%s %u ", vcode_op_string(op->kind), op->tag);
                vcode_dump_reg(op->args.items[0]);
             }
             break;


### PR DESCRIPTION
This fixes the assertion failure with output ports but needs a bit more code because we have to iterate over all the record fields again.